### PR TITLE
Performance enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ However, it is under-represented in libraries since there is little application 
 Fortunately, the science behind it has been studied by mathematicians for centuries, and is well understood and well documented. 
 However, mathematicians are focused on how many elements will exist within a Combinatorics problem, and have little interest in actually going through the work of creating those lists.  Enter computer science to actually construct these massive collections."
 
-You can [install the package from Nuget](https://www.nuget.org/packages/Nito.Combinatorics/)
+You can [install the package from Nuget](https://www.nuget.org/packages/Combinatorics/)
 
 > PM> Install-Package Combinatorics

--- a/src/Combinatorics/Combinations.cs
+++ b/src/Combinatorics/Combinations.cs
@@ -72,12 +72,12 @@ namespace Combinatorics.Collections
 
             Type = type;
             LowerIndex = lowerIndex;
-            _myValues = values.ToList();
+            _myValues = values is IList<T> list ? list : values.ToArray();
             List<bool> myMap;
             if (type == GenerateOption.WithoutRepetition)
             {
                 myMap = new List<bool>(_myValues.Count);
-                myMap.AddRange(_myValues.Select((t, i) => i < _myValues.Count - LowerIndex));
+                myMap.AddRange(_myValues.Select((_, i) => i < _myValues.Count - LowerIndex));
             }
             else
             {
@@ -238,7 +238,7 @@ namespace Combinatorics.Collections
         /// <summary>
         /// Copy of values object is initialized with, required for enumerator reset.
         /// </summary>
-        private readonly List<T> _myValues;
+        private readonly IList<T> _myValues;
 
         /// <summary>
         /// Permutations object that handles permutations on booleans for combination inclusion.

--- a/src/Combinatorics/Permutations.cs
+++ b/src/Combinatorics/Permutations.cs
@@ -92,8 +92,8 @@ namespace Combinatorics.Collections
             // Lexicographic Orders: {1 1 2 3 4 5 5}
 
             Type = type;
-            _myValues = values.ToList();
-            _myLexicographicOrders = new int[_myValues.Count];
+            _myValues = values is T[] array ? array : values.ToArray();
+            _myLexicographicOrders = new int[_myValues.Length];
 
             if (type == GenerateOption.WithRepetition)
             {
@@ -106,7 +106,8 @@ namespace Combinatorics.Collections
             {
                 comparer ??= Comparer<T>.Default;
 
-                _myValues.Sort(comparer);
+                Array.Sort(_myValues, comparer);
+
                 var j = 1;
                 if (_myLexicographicOrders.Length > 0)
                 {
@@ -149,7 +150,7 @@ namespace Combinatorics.Collections
                 _ = source ?? throw new ArgumentNullException(nameof(source));
                 _myParent = source;
                 _myLexicographicalOrders = new int[source._myLexicographicOrders.Length];
-                _myValues = new List<T>(source._myValues.Count);
+                _myValues = new List<T>(source._myValues.Length);
                 source._myLexicographicOrders.CopyTo(_myLexicographicalOrders, 0);
                 _myPosition = Position.BeforeFirst;
             }
@@ -327,13 +328,13 @@ namespace Combinatorics.Collections
         /// <summary>
         /// The upper index of the meta-collection, equal to the number of items in the input set.
         /// </summary>
-        public int UpperIndex => _myValues.Count;
+        public int UpperIndex => _myValues.Length;
 
         /// <summary>
         /// The lower index of the meta-collection, equal to the number of items returned each iteration.
         /// This is always equal to <see cref="UpperIndex"/>.
         /// </summary>
-        public int LowerIndex => _myValues.Count;
+        public int LowerIndex => _myValues.Length;
 
         /// <summary>
         /// Calculates the total number of permutations that will be returned.  
@@ -376,7 +377,7 @@ namespace Combinatorics.Collections
         /// <summary>
         /// A list of T that represents the order of elements as originally provided.
         /// </summary>
-        private readonly List<T> _myValues;
+        private readonly T[] _myValues;
 
         /// <summary>
         /// Parallel array of integers that represent the location of items in the myValues array.

--- a/src/Combinatorics/Variations.cs
+++ b/src/Combinatorics/Variations.cs
@@ -47,7 +47,7 @@ namespace Combinatorics.Collections
         {
             Type = type;
             LowerIndex = lowerIndex;
-            _myValues = values.ToList();
+            _myValues = values is List<T> list ? list : values.ToList();
 
             if (type != GenerateOption.WithoutRepetition)
             {


### PR DESCRIPTION
- Fix README NuGet package link 
- Performance enhancements
  - Use pattern match, use array instead of list when possible

Benchmark result, compare with the latest nuget package(2.0.0)

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22616
Intel Core i5-6300U CPU 2.40GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=7.0.100-preview.4.22252.9
  [Host]     : .NET Core 3.1.18 (CoreCLR 4.700.21.35901, CoreFX 4.700.21.36305), X64 RyuJIT
  DefaultJob : .NET Core 3.1.18 (CoreCLR 4.700.21.35901, CoreFX 4.700.21.36305), X64 RyuJIT


```
|       Method |          Mean |       Error |        StdDev |        Median | Ratio | RatioSD |      Gen 0 | Gen 1 | Gen 2 |   Allocated |
|------------- |--------------:|------------:|--------------:|--------------:|------:|--------:|-----------:|------:|------:|------------:|
| **EnumerateNew** | **26,443.776 μs** | **415.4109 μs** |   **368.2510 μs** | **26,455.742 μs** |  **0.92** |    **0.08** | **22187.5000** |     **-** |     **-** | **34021.69 KB** |
| **EnumerateOld** | **29,629.458 μs** | **896.6912 μs** | **2,469.7480 μs** | **29,110.257 μs** |  **1.00** |    **0.00** | **22142.8571** |     **-** |     **-** | **34021.72 KB** |
|              |               |             |               |               |       |         |            |       |       |             |
|    **Count0New** |      **2.422 μs** |   **0.0933 μs** |     **0.2720 μs** |      **2.319 μs** |  **1.20** |    **0.21** |     **0.9689** |     **-** |     **-** |     **1.48 KB** |
|    **Count0Old** |      **2.055 μs** |   **0.1102 μs** |     **0.3127 μs** |      **2.011 μs** |  **1.00** |    **0.00** |     **0.9880** |     **-** |     **-** |     **1.52 KB** |
|              |               |             |               |               |       |         |            |       |       |             |
|    **Count1New** |      **4.883 μs** |   **0.0945 μs** |     **0.1161 μs** |      **4.898 μs** |  **0.76** |    **0.05** |     **2.7771** |     **-** |     **-** |     **4.26 KB** |
|    **Count1Old** |      **5.785 μs** |   **0.2194 μs** |     **0.6434 μs** |      **5.559 μs** |  **1.00** |    **0.00** |     **2.8000** |     **-** |     **-** |     **4.29 KB** |
|              |               |             |               |               |       |         |            |       |       |             |
|    **Count2New** |      **6.007 μs** |   **0.1149 μs** |     **0.2042 μs** |      **6.034 μs** |  **0.97** |    **0.08** |     **3.1967** |     **-** |     **-** |      **4.9 KB** |
|    **Count2Old** |      **6.241 μs** |   **0.1338 μs** |     **0.3753 μs** |      **6.264 μs** |  **1.00** |    **0.00** |     **3.2120** |     **-** |     **-** |     **4.93 KB** |
